### PR TITLE
Update redhat-satellite.md

### DIFF
--- a/products/redhat-satellite.md
+++ b/products/redhat-satellite.md
@@ -33,7 +33,6 @@ releases:
     support: 2023-05-31
     latest: "6.12.4.1"
     latestReleaseDate: 2023-06-15
-    link: https://access.redhat.com/errata/RHBA-2023:2052
 
 -   releaseCycle: "6.11"
     releaseDate: 2022-07-05
@@ -41,7 +40,6 @@ releases:
     support: 2022-11-30
     latest: "6.11.5.4"
     latestReleaseDate: 2023-06-15
-    link: https://access.redhat.com/errata/RHBA-2023:1478
 
 -   releaseCycle: "6.10"
     releaseDate: 2021-11-16
@@ -49,7 +47,6 @@ releases:
     support: 2022-06-30
     latest: "6.10.7.2"
     latestReleaseDate: 2023-03-01
-    link: https://access.redhat.com/errata/RHBA-2023:1041
 
 -   releaseCycle: "6.9"
     releaseDate: 2021-04-21
@@ -57,7 +54,6 @@ releases:
     support: 2021-11-30
     latest: "6.9.10"
     latestReleaseDate: 2022-11-17
-    link: https://access.redhat.com/errata/RHSA-2022:8532
 
 ---
 


### PR DESCRIPTION
Removed `link` section from 6.12-6.9 release because they where out of date and are hard to track for each patch.